### PR TITLE
fix default too low error

### DIFF
--- a/kubernetes/configmap.yaml
+++ b/kubernetes/configmap.yaml
@@ -20,3 +20,8 @@ data:
   # comma separated list of values for the node selector values, e.g. "prodb-compute01, prodb-compute02"
   WORKER_NODE_SELECTOR_VALUES: ""
   MASTER_NODE_SELECTOR_VALUES: ""
+  DEFAULT_WORKER_COUNT: "4"
+  DEFAULT_WORKER_CORES: "1"
+  DEFAULT_WORKER_MEMORY: "50GiB"
+  DEFAULT_MASTER_CORES: "1"
+  DEFAULT_MASTER_MEMORY: "50GiB"

--- a/src/service/models.py
+++ b/src/service/models.py
@@ -2,6 +2,7 @@
 Pydantic models for the Spark Manager API.
 """
 
+import os
 from typing import Annotated
 
 from pydantic import BaseModel, ByteSize, Field
@@ -14,11 +15,11 @@ MAX_WORKER_COUNT = 25
 MAX_WORKER_CORES = 64
 MAX_MASTER_CORES = 64
 
-DEFAULT_WORKER_COUNT = 2
-DEFAULT_WORKER_CORES = 10
-DEFAULT_WORKER_MEMORY = "10GiB"
-DEFAULT_MASTER_CORES = 10
-DEFAULT_MASTER_MEMORY = "10GiB"
+DEFAULT_WORKER_COUNT = int(os.environ.get("DEFAULT_WORKER_COUNT", "4"))
+DEFAULT_WORKER_CORES = int(os.environ.get("DEFAULT_WORKER_CORES", "1"))
+DEFAULT_WORKER_MEMORY = os.environ.get("DEFAULT_WORKER_MEMORY", "50GiB")
+DEFAULT_MASTER_CORES = int(os.environ.get("DEFAULT_MASTER_CORES", "1"))
+DEFAULT_MASTER_MEMORY = os.environ.get("DEFAULT_MASTER_MEMORY", "50GiB")
 
 
 class SparkClusterConfig(BaseModel):

--- a/src/spark_manager.py
+++ b/src/spark_manager.py
@@ -62,11 +62,11 @@ class KubeSparkManager:
     MASTER_SERVICE_TEMPLATE = str(TEMPLATES_DIR / MASTER_SERVICE_TEMPLATE_FILE)
 
     # Default configuration values for cluster settings
-    DEFAULT_WORKER_COUNT = 2
-    DEFAULT_WORKER_CORES = 10
-    DEFAULT_WORKER_MEMORY = "10G"
-    DEFAULT_MASTER_CORES = 10
-    DEFAULT_MASTER_MEMORY = "10G"
+    DEFAULT_WORKER_COUNT = int(os.environ.get("DEFAULT_WORKER_COUNT", "4"))
+    DEFAULT_WORKER_CORES = int(os.environ.get("DEFAULT_WORKER_CORES", "1"))
+    DEFAULT_WORKER_MEMORY = os.environ.get("DEFAULT_WORKER_MEMORY", "50GiB")
+    DEFAULT_MASTER_CORES = int(os.environ.get("DEFAULT_MASTER_CORES", "1"))
+    DEFAULT_MASTER_MEMORY = os.environ.get("DEFAULT_MASTER_MEMORY", "50GiB")
 
     DEFAULT_IMAGE_PULL_POLICY = os.environ.get(
         "SPARK_IMAGE_PULL_POLICY", "IfNotPresent"


### PR DESCRIPTION
We increased the resources on the JupyterHub side but did not adjust them on the Spark manager side.
```
  File "/app/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 301, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 212, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/src/routes/clusters.py", line 62, in create_cluster
    raise ConfigurationLimitExceededError(
src.service.exceptions.ConfigurationLimitExceededError: Configuration exceeds default limits for non-admin users. Max Workers: 2, Max Worker Cores: 10, Max Worker Memory: 10.0GiB, Max Master Cores: 10, Max Master Memory: 10.0GiB.
```